### PR TITLE
Fix compile error with recent dns library

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func queryDNS(domain string, rrtype uint16) (*dns.Msg, error) {
 	tcpClient := &dns.Client{Net: "tcp"}
 
 	resp, _, err := udpClient.Exchange(msg, resolver)
-	if err == dns.ErrTruncated || (err == nil && resp.Truncated) {
+	if err == nil && resp.Truncated {
 		resp, _, err = tcpClient.Exchange(msg, resolver)
 	}
 	if err != nil {


### PR DESCRIPTION
dns removed the ErrTruncated library (https://github.com/miekg/dns/pull/815).
Checking Truncated is sufficient.